### PR TITLE
Handle invalid Telegram credentials before starting dispatcher

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use anyhow::Result as AnyResult;
+use anyhow::{Context, Result as AnyResult};
 use dotenv::dotenv;
 use teloxide::prelude::*;
 
@@ -9,6 +9,14 @@ mod telegram;
 
 use handlers::process_video;
 
+async fn ensure_bot_credentials(bot: &Bot) -> AnyResult<()> {
+    bot.get_me()
+        .send()
+        .await
+        .context("Failed to authenticate bot with Telegram API. Check BOT_TOKEN")?;
+    Ok(())
+}
+
 #[tokio::main]
 async fn main() -> AnyResult<()> {
     dotenv().ok();
@@ -16,6 +24,11 @@ async fn main() -> AnyResult<()> {
     log::info!("Starting bot");
 
     let bot = Bot::from_env();
+
+    if let Err(error) = ensure_bot_credentials(&bot).await {
+        log::error!("{error:?}");
+        return Err(error);
+    }
 
     teloxide::repl(bot, |bot: Bot, msg: Message| async move {
         if let Err(e) = process_video(&bot, &msg).await {


### PR DESCRIPTION
### Motivation
- Prevent the teloxide dispatcher from panicking when the bot token is invalid by validating Telegram credentials at startup and returning a clear contextual error.

### Description
- Add `ensure_bot_credentials` which calls `bot.get_me().send().await` and returns a contextual error (`Failed to authenticate bot with Telegram API. Check BOT_TOKEN`) and invoke it before starting `teloxide::repl` to log and exit cleanly on failure.

### Testing
- Ran `cargo fmt --all` and `cargo test`, and the test suite passed (`4 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a62ca51cf48332ba0e33e44881e8bf)