### PR TITLE
Harden MKV→MP4 conversion with safer FFmpeg pipeline and cleanup

### DIFF
--- a/src/converter.rs
+++ b/src/converter.rs
@@ -1,14 +1,77 @@
-use anyhow::{anyhow, Result as AnyResult};
+use anyhow::{anyhow, Context, Result as AnyResult};
+use std::path::{Path, PathBuf};
 use std::process::Command;
+
+fn build_output_path(file_path: &str) -> String {
+    let path = Path::new(file_path);
+    let mut output_path = PathBuf::from(path);
+    output_path.set_extension("mp4");
+    output_path.to_string_lossy().to_string()
+}
 
 /// Конвертирует любой поддерживаемый FFmpeg видеофайл в формат `.mp4`.
 pub fn convert_video_to_mp4(file_path: &str) -> AnyResult<String> {
-    let output_path = format!("{}.mp4", file_path);
+    let output_path = build_output_path(file_path);
     let output = Command::new("ffmpeg")
-        .args(["-y", "-i", file_path, &output_path])
+        .args([
+            "-hide_banner",
+            "-nostdin",
+            "-y",
+            "-i",
+            file_path,
+            "-map",
+            "0:v:0",
+            "-map",
+            "0:a?",
+            "-c:v",
+            "libx264",
+            "-preset",
+            "veryfast",
+            "-crf",
+            "23",
+            "-pix_fmt",
+            "yuv420p",
+            "-c:a",
+            "aac",
+            "-b:a",
+            "192k",
+            "-movflags",
+            "+faststart",
+            &output_path,
+        ])
         .output()?;
+
     if !output.status.success() {
-        return Err(anyhow!("FFmpeg conversion failed: {:?}", output));
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        return Err(anyhow!(
+            "FFmpeg conversion failed (status: {}): stderr='{}' stdout='{}'",
+            output.status.code().map_or_else(
+                || "terminated by signal".to_string(),
+                |code| code.to_string()
+            ),
+            stderr,
+            stdout,
+        ));
     }
+
+    std::fs::metadata(&output_path)
+        .with_context(|| format!("Converted file is missing: {}", output_path))?;
+
     Ok(output_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_output_path;
+
+    #[test]
+    fn replaces_existing_extension_with_mp4() {
+        assert_eq!(build_output_path("/tmp/example.mkv"), "/tmp/example.mp4");
+    }
+
+    #[test]
+    fn appends_mp4_when_extension_absent() {
+        assert_eq!(build_output_path("/tmp/example"), "/tmp/example.mp4");
+    }
 }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -76,54 +76,64 @@ pub async fn process_video(bot: &Bot, msg: &Message) -> AnyResult<()> {
     // Скачиваем файл.
     let file_path = download_file(bot, &file_id).await?;
 
-    // Клонируем file_path для передачи в замыкание, чтобы оригинал оставался доступен
-    let file_path_clone = file_path.clone();
+    let mut converted_file_path: Option<String> = None;
 
-    // Конвертация файла выполняется в отдельном блокирующем потоке.
-    let join_result = task::spawn_blocking(move || convert_video_to_mp4(&file_path_clone))
-        .await
-        .context("Failed to join blocking task")?;
-    let converted_file_path = join_result.context("FFmpeg conversion failed")?;
+    let processing_result: AnyResult<()> = async {
+        // Клонируем file_path для передачи в замыкание, чтобы оригинал оставался доступен
+        let file_path_clone = file_path.clone();
 
-    // Формируем запрос на отправку видео.
-    let mut send_video_request = bot
-        .send_video(msg.chat.id, InputFile::file(&converted_file_path))
-        .disable_notification(true);
+        // Конвертация файла выполняется в отдельном блокирующем потоке.
+        let join_result = task::spawn_blocking(move || convert_video_to_mp4(&file_path_clone))
+            .await
+            .context("Failed to join blocking task")?;
+        let converted_path = join_result.context("FFmpeg conversion failed")?;
+        converted_file_path = Some(converted_path.clone());
 
-    if let Some(thread_id) = msg.thread_id {
-        send_video_request = send_video_request.message_thread_id(thread_id);
+        // Формируем запрос на отправку видео.
+        let mut send_video_request = bot
+            .send_video(msg.chat.id, InputFile::file(&converted_path))
+            .disable_notification(true);
+
+        if let Some(thread_id) = msg.thread_id {
+            send_video_request = send_video_request.message_thread_id(thread_id);
+        }
+
+        if let Some(user) = msg.from() {
+            let full_name = user.full_name();
+            let signature = format!("send by [{}](tg://user?id={})", full_name, user.id);
+            let caption = msg.caption().map_or_else(
+                || signature.clone(),
+                |existing_caption| format!("{}\n\n{}", existing_caption, signature),
+            );
+            send_video_request = send_video_request
+                .caption(caption)
+                .allow_sending_without_reply(true);
+        }
+
+        if let Some(reply_msg) = msg.reply_to_message() {
+            send_video_request = send_video_request.reply_to_message_id(reply_msg.id);
+        }
+
+        send_video_request = send_video_request.parse_mode(ParseMode::MarkdownV2);
+        send_video_request.await?;
+
+        // Удаляем оригинальное сообщение.
+        bot.delete_message(msg.chat.id, msg.id).await?;
+
+        Ok(())
     }
+    .await;
 
-    if let Some(user) = msg.from() {
-        let full_name = user.full_name();
-        let signature = format!("send by [{}](tg://user?id={})", full_name, user.id);
-        let caption = msg.caption().map_or_else(
-            || signature.clone(),
-            |existing_caption| format!("{}\n\n{}", existing_caption, signature),
-        );
-        send_video_request = send_video_request
-            .caption(caption)
-            .allow_sending_without_reply(true);
-    }
-
-    if let Some(reply_msg) = msg.reply_to_message() {
-        send_video_request = send_video_request.reply_to_message_id(reply_msg.id);
-    }
-    send_video_request = send_video_request.parse_mode(ParseMode::MarkdownV2);
-    send_video_request.await?;
-
-    // Удаляем оригинальное сообщение.
-    bot.delete_message(msg.chat.id, msg.id).await?;
-
-    // Асинхронное удаление временных файлов с логированием ошибок.
     if let Err(e) = fs::remove_file(&file_path).await {
         log::error!("Error deleting file {}: {:?}", file_path, e);
     }
-    if let Err(e) = fs::remove_file(&converted_file_path).await {
-        log::error!("Error deleting file {}: {:?}", converted_file_path, e);
+    if let Some(converted_path) = converted_file_path {
+        if let Err(e) = fs::remove_file(&converted_path).await {
+            log::error!("Error deleting file {}: {:?}", converted_path, e);
+        }
     }
 
-    Ok(())
+    processing_result
 }
 
 #[cfg(test)]


### PR DESCRIPTION
### Motivation
- Fix unreliable behavior and silent failures when users send MKV files by making the conversion deterministic and observable. 
- Prevent the bot from hanging or producing no logs by removing potential blocking stdin and surfacing FFmpeg diagnostics. 
- Ensure temporary files are always cleaned up to avoid leaking disk space on failure paths.

### Description
- Replaced naive output naming with `build_output_path` that correctly replaces the original extension with `.mp4` in `src/converter.rs`.
- Invoke `ffmpeg` with explicit, Telegram-compatible parameters (`-map 0:v:0 -map 0:a? -c:v libx264 -c:a aac -pix_fmt yuv420p -movflags +faststart -nostdin`) to force consistent re-encoding and avoid stdin blocking. 
- Improve error reporting by including FFmpeg exit status, `stderr` and `stdout` text, and add a post-conversion `std::fs::metadata` check to verify the output file was actually created in `src/converter.rs`.
- Make cleanup robust by capturing the converted path and deleting both original and converted temporary files after processing, even if conversion/upload fails, and restructure `process_video` flow to return the processing result in `src/handlers.rs`.
- Add unit tests for output-path generation in `src/converter.rs` and keep existing document/video detection tests.

### Testing
- Ran formatting and tests with `cargo fmt --all && cargo test` and all unit tests passed (`9 passed; 0 failed`).
- Verified the new converter tests for output path and existing handler/telegram tests all succeed under CI-like local test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6947747ec8332a2cae33378d33c10)