### PR TITLE
Add per-user/global daily rate limits and username sanitization

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,5 +43,11 @@ Set the following environment variables:
 Send a video file (for example, `.webm`, `.mkv`, `.mov`) to the chat with the bot, and it will send a converted `.mp4` file and delete the original message.
 Also shows tg ID's of new members.
 
+## Rate limits
+- `USER_DAILY_LIMIT` (default: `10`) — maximum conversions per user per UTC day.
+- `GLOBAL_DAILY_LIMIT` (default: `50`) — maximum conversions for the whole bot per UTC day.
+
+The bot logs quota decisions and resets counters at UTC midnight.
+
 ## Contributing
 Contributions are welcome. Please send pull requests.

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -38,7 +38,7 @@ fn sanitize_user_name(name: Option<&str>) -> String {
 
     if name.chars().all(|ch| {
         ch.is_ascii_alphanumeric()
-            || ch.is_ascii_whitespace()
+            || ch == ' '
             || ('А'..='я').contains(&ch)
             || matches!(ch, 'Ё' | 'ё' | '_' | '-' | '.' | ' ')
     }) {
@@ -48,13 +48,27 @@ fn sanitize_user_name(name: Option<&str>) -> String {
     }
 }
 
+fn quota_subject_key(msg: &Message) -> i64 {
+    if let Some(user) = msg.from() {
+        return user.id.0 as i64;
+    }
+
+    // For channel/anonymous messages without `from`, avoid a shared bucket (0)
+    // by assigning a synthetic per-message key scoped by chat + message id.
+    synthetic_quota_key(msg.chat.id.0, i64::from(msg.id.0))
+}
+
+fn synthetic_quota_key(chat_id: i64, message_id: i64) -> i64 {
+    chat_id.wrapping_mul(1_000_003).wrapping_add(message_id) ^ i64::MIN
+}
+
 pub async fn process_video(
     bot: &Bot,
     msg: &Message,
     limiter: &Mutex<RateLimiter>,
 ) -> AnyResult<()> {
     let user = msg.from();
-    let user_id = user.map_or(0, |u| u.id.0 as i64);
+    let user_id = quota_subject_key(msg);
     let user_name = sanitize_user_name(user.map(|u| u.full_name()).as_deref());
 
     log::info!(
@@ -242,7 +256,7 @@ pub async fn process_video(
 
 #[cfg(test)]
 mod tests {
-    use super::{is_video_document, sanitize_user_name};
+    use super::{is_video_document, sanitize_user_name, synthetic_quota_key};
 
     #[test]
     fn detects_video_mime_type() {
@@ -276,5 +290,22 @@ mod tests {
     #[test]
     fn replaces_unsafe_name() {
         assert_eq!(sanitize_user_name(Some("bad🚀name")), "eblan with symbols");
+    }
+
+    #[test]
+    fn rejects_control_whitespace_name() {
+        assert_eq!(
+            sanitize_user_name(Some("Ivan\nAdmin")),
+            "eblan with symbols"
+        );
+    }
+
+    #[test]
+    fn generates_non_zero_synthetic_quota_key() {
+        assert_ne!(synthetic_quota_key(-1001234567890, 42), 0);
+        assert_ne!(
+            synthetic_quota_key(-1001234567890, 42),
+            synthetic_quota_key(-1001234567890, 43)
+        );
     }
 }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -3,9 +3,10 @@ use teloxide::{
     prelude::*,
     types::{InputFile, MediaKind, MessageKind, ParseMode},
 };
-use tokio::{fs, task};
+use tokio::{fs, sync::Mutex, task};
 
 use crate::converter::convert_video_to_mp4;
+use crate::limits::{utc_day_index, QuotaDecision, RateLimiter};
 use crate::telegram::download_file;
 
 const VIDEO_FILE_EXTENSIONS: &[&str] = &[
@@ -30,7 +31,40 @@ fn is_video_document(mime_type: Option<&str>, file_name: Option<&str>) -> bool {
     file_name.map(has_video_extension).unwrap_or(false)
 }
 
-pub async fn process_video(bot: &Bot, msg: &Message) -> AnyResult<()> {
+fn sanitize_user_name(name: Option<&str>) -> String {
+    let Some(name) = name else {
+        return "unknown".to_string();
+    };
+
+    if name.chars().all(|ch| {
+        ch.is_ascii_alphanumeric()
+            || ch.is_ascii_whitespace()
+            || ('А'..='я').contains(&ch)
+            || matches!(ch, 'Ё' | 'ё' | '_' | '-' | '.' | ' ')
+    }) {
+        name.to_string()
+    } else {
+        "eblan with symbols".to_string()
+    }
+}
+
+pub async fn process_video(
+    bot: &Bot,
+    msg: &Message,
+    limiter: &Mutex<RateLimiter>,
+) -> AnyResult<()> {
+    let user = msg.from();
+    let user_id = user.map_or(0, |u| u.id.0 as i64);
+    let user_name = sanitize_user_name(user.map(|u| u.full_name()).as_deref());
+
+    log::info!(
+        "Incoming message: chat_id={}, message_id={}, user_id={}, user_name='{}'",
+        msg.chat.id,
+        msg.id,
+        user_id,
+        user_name,
+    );
+
     let MessageKind::Common(common) = &msg.kind else {
         return Ok(());
     };
@@ -72,6 +106,76 @@ pub async fn process_video(bot: &Bot, msg: &Message) -> AnyResult<()> {
         }
         _ => return Ok(()),
     };
+
+    let quota_decision = {
+        let mut limiter = limiter.lock().await;
+        limiter.check_and_consume(user_id, utc_day_index(std::time::SystemTime::now()))
+    };
+
+    match quota_decision {
+        QuotaDecision::Allowed {
+            user_count,
+            user_limit,
+            global_count,
+            global_limit,
+            day_index,
+        } => {
+            log::info!(
+                "Quota allowed: day={}, user_id={}, user_count={}/{}, global_count={}/{}",
+                day_index,
+                user_id,
+                user_count,
+                user_limit,
+                global_count,
+                global_limit,
+            );
+        }
+        QuotaDecision::UserLimitExceeded {
+            user_count,
+            user_limit,
+            global_count,
+            global_limit,
+            day_index,
+        } => {
+            log::warn!(
+                "User daily limit exceeded: day={}, user_id={}, user_count={}/{}, global_count={}/{}",
+                day_index,
+                user_id,
+                user_count,
+                user_limit,
+                global_count,
+                global_limit,
+            );
+            bot.send_message(
+                msg.chat.id,
+                format!(
+                    "Daily limit exceeded: {}/{} videos for today. Try again tomorrow (UTC).",
+                    user_count, user_limit
+                ),
+            )
+            .await?;
+            return Ok(());
+        }
+        QuotaDecision::GlobalLimitExceeded {
+            global_count,
+            global_limit,
+            day_index,
+        } => {
+            log::warn!(
+                "Global daily limit exceeded: day={}, user_id={}, global_count={}/{}",
+                day_index,
+                user_id,
+                global_count,
+                global_limit,
+            );
+            bot.send_message(
+                msg.chat.id,
+                "Service daily conversion limit is exhausted. Please try again tomorrow (UTC).",
+            )
+            .await?;
+            return Ok(());
+        }
+    }
 
     // Скачиваем файл.
     let file_path = download_file(bot, &file_id).await?;
@@ -138,7 +242,7 @@ pub async fn process_video(bot: &Bot, msg: &Message) -> AnyResult<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::is_video_document;
+    use super::{is_video_document, sanitize_user_name};
 
     #[test]
     fn detects_video_mime_type() {
@@ -162,5 +266,15 @@ mod tests {
             Some("application/pdf"),
             Some("document.pdf")
         ));
+    }
+
+    #[test]
+    fn keeps_safe_name() {
+        assert_eq!(sanitize_user_name(Some("Иван Ivan_01")), "Иван Ivan_01");
+    }
+
+    #[test]
+    fn replaces_unsafe_name() {
+        assert_eq!(sanitize_user_name(Some("bad🚀name")), "eblan with symbols");
     }
 }

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -1,0 +1,190 @@
+use std::collections::HashMap;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+#[derive(Debug, Clone)]
+pub enum QuotaDecision {
+    Allowed {
+        user_count: u32,
+        user_limit: u32,
+        global_count: u32,
+        global_limit: u32,
+        day_index: u64,
+    },
+    UserLimitExceeded {
+        user_count: u32,
+        user_limit: u32,
+        global_count: u32,
+        global_limit: u32,
+        day_index: u64,
+    },
+    GlobalLimitExceeded {
+        global_count: u32,
+        global_limit: u32,
+        day_index: u64,
+    },
+}
+
+#[derive(Debug)]
+pub struct RateLimiter {
+    day_index: u64,
+    user_daily_limit: u32,
+    global_daily_limit: u32,
+    global_count: u32,
+    user_counts: HashMap<i64, u32>,
+}
+
+pub fn utc_day_index(now: SystemTime) -> u64 {
+    now.duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::from_secs(0))
+        .as_secs()
+        / 86_400
+}
+
+impl RateLimiter {
+    pub fn new(user_daily_limit: u32, global_daily_limit: u32) -> Self {
+        Self {
+            day_index: utc_day_index(SystemTime::now()),
+            user_daily_limit,
+            global_daily_limit,
+            global_count: 0,
+            user_counts: HashMap::new(),
+        }
+    }
+
+    pub fn current_day_index(&self) -> u64 {
+        self.day_index
+    }
+
+    pub fn reset_if_new_day(&mut self, now_day_index: u64) -> bool {
+        if now_day_index != self.day_index {
+            self.day_index = now_day_index;
+            self.global_count = 0;
+            self.user_counts.clear();
+            return true;
+        }
+        false
+    }
+
+    pub fn check_and_consume(&mut self, user_id: i64, now_day_index: u64) -> QuotaDecision {
+        self.reset_if_new_day(now_day_index);
+
+        if self.global_count >= self.global_daily_limit {
+            return QuotaDecision::GlobalLimitExceeded {
+                global_count: self.global_count,
+                global_limit: self.global_daily_limit,
+                day_index: self.day_index,
+            };
+        }
+
+        let user_count = *self.user_counts.get(&user_id).unwrap_or(&0);
+        if user_count >= self.user_daily_limit {
+            return QuotaDecision::UserLimitExceeded {
+                user_count,
+                user_limit: self.user_daily_limit,
+                global_count: self.global_count,
+                global_limit: self.global_daily_limit,
+                day_index: self.day_index,
+            };
+        }
+
+        let new_user_count = user_count + 1;
+        let new_global_count = self.global_count + 1;
+
+        self.user_counts.insert(user_id, new_user_count);
+        self.global_count = new_global_count;
+
+        QuotaDecision::Allowed {
+            user_count: new_user_count,
+            user_limit: self.user_daily_limit,
+            global_count: new_global_count,
+            global_limit: self.global_daily_limit,
+            day_index: self.day_index,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{utc_day_index, QuotaDecision, RateLimiter};
+    use std::time::{Duration, UNIX_EPOCH};
+
+    #[test]
+    fn enforces_per_user_limit() {
+        let mut limiter = RateLimiter::new(2, 100);
+        let day = 20_000;
+
+        assert!(matches!(
+            limiter.check_and_consume(1, day),
+            QuotaDecision::Allowed { user_count: 1, .. }
+        ));
+        assert!(matches!(
+            limiter.check_and_consume(1, day),
+            QuotaDecision::Allowed { user_count: 2, .. }
+        ));
+        assert!(matches!(
+            limiter.check_and_consume(1, day),
+            QuotaDecision::UserLimitExceeded {
+                user_count: 2,
+                user_limit: 2,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn enforces_global_limit() {
+        let mut limiter = RateLimiter::new(10, 2);
+        let day = 20_000;
+
+        assert!(matches!(
+            limiter.check_and_consume(1, day),
+            QuotaDecision::Allowed {
+                global_count: 1,
+                ..
+            }
+        ));
+        assert!(matches!(
+            limiter.check_and_consume(2, day),
+            QuotaDecision::Allowed {
+                global_count: 2,
+                ..
+            }
+        ));
+        assert!(matches!(
+            limiter.check_and_consume(3, day),
+            QuotaDecision::GlobalLimitExceeded {
+                global_count: 2,
+                global_limit: 2,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn resets_on_new_day() {
+        let mut limiter = RateLimiter::new(1, 1);
+        let day1 = 20_000;
+        let day2 = day1 + 1;
+
+        assert!(matches!(
+            limiter.check_and_consume(1, day1),
+            QuotaDecision::Allowed { .. }
+        ));
+        assert!(matches!(
+            limiter.check_and_consume(1, day1),
+            QuotaDecision::GlobalLimitExceeded { .. }
+        ));
+        assert!(matches!(
+            limiter.check_and_consume(1, day2),
+            QuotaDecision::Allowed { .. }
+        ));
+    }
+
+    #[test]
+    fn computes_utc_day_index() {
+        let start = UNIX_EPOCH + Duration::from_secs(0);
+        let next_day = UNIX_EPOCH + Duration::from_secs(86_400);
+        assert_eq!(utc_day_index(start), 0);
+        assert_eq!(utc_day_index(next_day), 1);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,24 @@
 use anyhow::{Context, Result as AnyResult};
 use dotenv::dotenv;
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use teloxide::prelude::*;
+use tokio::{
+    sync::Mutex,
+    time::{sleep, Duration as TokioDuration},
+};
 
 // Модульная структура
 mod converter;
 mod handlers;
+mod limits;
 mod telegram;
 
 use handlers::process_video;
+use limits::{utc_day_index, RateLimiter};
+
+const DEFAULT_USER_DAILY_LIMIT: u32 = 10;
+const DEFAULT_GLOBAL_DAILY_LIMIT: u32 = 50;
 
 async fn ensure_bot_credentials(bot: &Bot) -> AnyResult<()> {
     bot.get_me()
@@ -17,11 +28,70 @@ async fn ensure_bot_credentials(bot: &Bot) -> AnyResult<()> {
     Ok(())
 }
 
+fn next_midnight_utc_seconds() -> u64 {
+    let now_secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::from_secs(0))
+        .as_secs();
+    let secs_into_day = now_secs % 86_400;
+    if secs_into_day == 0 {
+        86_400
+    } else {
+        86_400 - secs_into_day
+    }
+}
+
+fn parse_env_limit(name: &str, default: u32) -> u32 {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse::<u32>().ok())
+        .unwrap_or(default)
+}
+
+async fn start_quota_monitor(limiter: Arc<Mutex<RateLimiter>>) {
+    loop {
+        sleep(TokioDuration::from_secs(60)).await;
+        let now_day_index = utc_day_index(SystemTime::now());
+        let mut limiter = limiter.lock().await;
+        if limiter.reset_if_new_day(now_day_index) {
+            log::info!(
+                "Daily quotas reset at UTC midnight: day_index={}, next_reset_in_seconds={}",
+                now_day_index,
+                next_midnight_utc_seconds(),
+            );
+        }
+    }
+}
+
 #[tokio::main]
 async fn main() -> AnyResult<()> {
     dotenv().ok();
     pretty_env_logger::init();
     log::info!("Starting bot");
+
+    let user_daily_limit = parse_env_limit("USER_DAILY_LIMIT", DEFAULT_USER_DAILY_LIMIT);
+    let global_daily_limit = parse_env_limit("GLOBAL_DAILY_LIMIT", DEFAULT_GLOBAL_DAILY_LIMIT);
+
+    let limiter = Arc::new(Mutex::new(RateLimiter::new(
+        user_daily_limit,
+        global_daily_limit,
+    )));
+    let monitor_limiter = Arc::clone(&limiter);
+
+    {
+        let limiter = limiter.lock().await;
+        log::info!(
+            "Rate limits initialized: day_index={}, user_daily_limit={}, global_daily_limit={}, next_reset_in_seconds={}",
+            limiter.current_day_index(),
+            user_daily_limit,
+            global_daily_limit,
+            next_midnight_utc_seconds(),
+        );
+    }
+
+    tokio::spawn(async move {
+        start_quota_monitor(monitor_limiter).await;
+    });
 
     let bot = Bot::from_env();
 
@@ -30,11 +100,14 @@ async fn main() -> AnyResult<()> {
         return Err(error);
     }
 
-    teloxide::repl(bot, |bot: Bot, msg: Message| async move {
-        if let Err(e) = process_video(&bot, &msg).await {
-            log::error!("Error processing video file: {:?}", e);
+    teloxide::repl(bot, move |bot: Bot, msg: Message| {
+        let limiter = Arc::clone(&limiter);
+        async move {
+            if let Err(e) = process_video(&bot, &msg, &limiter).await {
+                log::error!("Error processing video file: {:?}", e);
+            }
+            respond(())
         }
-        respond(())
     })
     .await;
     Ok(())


### PR DESCRIPTION
### Motivation
- Prevent excessive/concurrent video conversions and abuse by introducing per-user and global daily quotas and logging quota decisions.
- Ensure logged user names are safe to display by replacing names that contain non-whitelisted symbols.
- Provide configuration knobs and automatic reset of counters at UTC midnight.

### Description
- Add `src/limits.rs` implementing `RateLimiter`, `QuotaDecision`, and `utc_day_index`, with in-memory per-user and global counters and reset logic.
- Integrate rate limiting into `process_video` by accepting a `Mutex<RateLimiter>`, checking `check_and_consume`, logging outcomes, and replying with user- or global-limit messages when exceeded; also add `sanitize_user_name` to normalize or replace unsafe names.
- Initialize the limiter in `main.rs` from env vars `USER_DAILY_LIMIT` and `GLOBAL_DAILY_LIMIT`, spawn a background `start_quota_monitor` task to reset counters at UTC midnight, and pass the limiter to the message handler; add helper functions `parse_env_limit` and `next_midnight_utc_seconds`.
- Update `README.md` to document the new `USER_DAILY_LIMIT` and `GLOBAL_DAILY_LIMIT` environment variables and note quota behaviour.
- Add unit tests for limiter behavior and name sanitization and extend existing document/video detection tests.

### Testing
- Ran `cargo test` covering `limits` unit tests `enforces_per_user_limit`, `enforces_global_limit`, `resets_on_new_day`, and `computes_utc_day_index`, which passed.
- Ran `handlers` unit tests `detects_video_mime_type`, `detects_video_extension_without_video_mime`, `skips_non_video_documents`, `keeps_safe_name`, and `replaces_unsafe_name`, which passed.
- No runtime integration tests were included in this change; basic bot startup path was exercised locally and logged limiter initialization without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6965753748332b40071a162134963)