### PR TITLE
Update muslrust builder image to support Cargo.lock v4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build Stage
-FROM clux/muslrust:1.75.0-stable as builder
+FROM clux/muslrust:1.85.0-stable AS builder
 WORKDIR /home/rust/src
 
 # Cache dependencies
@@ -20,7 +20,7 @@ RUN touch src/main.rs
 RUN cargo build --release --target x86_64-unknown-linux-musl
 
 # Run Stage
-FROM alpine:3.19 as runtime
+FROM alpine:3.19 AS runtime
 
 # Install FFmpeg
 RUN apk add --no-cache ffmpeg


### PR DESCRIPTION
### Motivation
- Bump the Docker Rust builder image so the Cargo in the build environment can read lockfile version `4` and avoid the "lock file version `4` was found" build error.

### Description
- Update `Dockerfile` to use `clux/muslrust:1.85.0-stable` for the build stage and normalize stage alias casing to `AS` to address `FromAsCasing` warnings.

### Testing
- Ran `cargo check` which completed successfully, and attempted `docker build -t shitverter-test .` but `docker` is not available in this environment so the image build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a75510443c83329d0c9374f5a7bd35)