### PR TITLE
Set pretty_env_logger default filter to info with RUST_LOG override

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ docker run -d --env-file .env --name my_shitverter_container shitverter:latest
 ## Configuration
 Set the following environment variables:
 - `TELOXIDE_TOKEN`: Your Telegram Bot Token.
+- `RUST_LOG`: Log level filter for the bot output (example: `RUST_LOG=info`, default: `info`).
 
 If a local `.env` file exists, `run.sh` and `rebuild.sh` automatically pass it to
 `docker run` using `--env-file .env`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,9 @@ async fn start_quota_monitor(limiter: Arc<Mutex<RateLimiter>>) {
 #[tokio::main]
 async fn main() -> AnyResult<()> {
     dotenv().ok();
-    pretty_env_logger::init();
+    pretty_env_logger::formatted_timed_builder()
+        .parse_filters(&std::env::var("RUST_LOG").unwrap_or_else(|_| "info".to_string()))
+        .init();
     log::info!("Starting bot");
 
     let user_daily_limit = parse_env_limit("USER_DAILY_LIMIT", DEFAULT_USER_DAILY_LIMIT);


### PR DESCRIPTION
### Motivation
- Ensure that informational logs (e.g. `Starting bot`) are visible by default in container logs when `RUST_LOG` is not set.
- Allow operators to override the log level via `RUST_LOG` without changing code.

### Description
- Replace `pretty_env_logger::init()` in `src/main.rs` with a builder using `pretty_env_logger::formatted_timed_builder()` and `.parse_filters(...)` to read `RUST_LOG` with a fallback of `info`.
- Keep existing logging calls unchanged so default `info` output is visible while `RUST_LOG` can override the level (for example `RUST_LOG=debug`).
- Add a `RUST_LOG` configuration example to the `Configuration` section of `README.md` explaining the default and usage (example: `RUST_LOG=info`).

### Testing
- Ran `cargo check` which completed successfully.
- Ran `cargo build` which completed successfully.
- Ran the built binary with `unset RUST_LOG; TELOXIDE_TOKEN=... ./target/debug/converter-bot` and observed `INFO` logs including `Starting bot`, confirming the `info` fallback worked.
- Ran with `RUST_LOG=error TELOXIDE_TOKEN=... ./target/debug/converter-bot` and observed only `ERROR`-level output, confirming `RUST_LOG` overrides the default.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a769219f948332b460243cd78541ec)