### PR TITLE
Improve Docker image build, runtime hardening, and docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+# Rust build artifacts
+target/
+
+# VCS / IDE
+.git/
+.github/
+.vscode/
+
+# Local config/secrets
+.env
+
+# Misc
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,46 @@
-# Build Stage
-FROM clux/muslrust:1.85.0-stable AS builder
-WORKDIR /home/rust/src
+# syntax=docker/dockerfile:1
+#
+# Multi-stage build:
+# - build-env: Rust toolchain + musl C toolchain (not shipped to prod)
+# - builder:   compiles the release binary for musl
+# - runtime:   minimal Alpine + ffmpeg + the binary
+#
+# To pin the toolchain for reproducibility:
+#   docker build --build-arg MUSLRUST_TAG=1.93.1-stable-2026-02-23 -t shitverter:latest .
 
-# Cache dependencies
-# Copy Cargo.toml and Cargo.lock and create a dummy main file
+ARG MUSLRUST_TAG=stable
+
+FROM clux/muslrust:${MUSLRUST_TAG} AS build-env
+WORKDIR /app
+
+FROM build-env AS builder
+
+# Strip symbols at compile time to reduce binary size.
+ENV RUSTFLAGS="-C strip=symbols"
+
+# ---- dependency cache (keeps rebuilds fast) ----
 COPY Cargo.toml Cargo.lock ./
-RUN mkdir src && echo "fn main() {}" > src/main.rs
+RUN mkdir -p src && printf "fn main() {}\n" > src/main.rs
+RUN cargo build --release --locked --target x86_64-unknown-linux-musl
 
-# Build only the dependencies to cache them
-RUN cargo build --release --target x86_64-unknown-linux-musl
+# ---- build the real application ----
+RUN rm -f src/main.rs
+COPY src ./src
+RUN cargo build --release --locked --target x86_64-unknown-linux-musl
 
-# Now copy the actual source code
-COPY ./ ./
+# ---- production runtime ----
+FROM alpine:3.23.3 AS runtime
 
-# Touch the main file to update its timestamp
-RUN touch src/main.rs
+# ffmpeg is required for video conversion; ca-certificates is needed for HTTPS (Telegram API).
+RUN apk add --no-cache ffmpeg ca-certificates \
+  && addgroup -S app \
+  && adduser -S -G app app \
+  && mkdir -p /tmp \
+  && chown -R app:app /tmp
 
-# Build the actual application
-RUN cargo build --release --target x86_64-unknown-linux-musl
+COPY --from=builder --chown=app:app /app/target/x86_64-unknown-linux-musl/release/converter-bot /usr/local/bin/converter-bot
 
-# Run Stage
-FROM alpine:3.19 AS runtime
-
-# Install FFmpeg
-RUN apk add --no-cache ffmpeg
-
-# Copy the compiled binary from the builder stage
-COPY --from=builder /home/rust/src/target/x86_64-unknown-linux-musl/release/converter-bot /usr/local/bin/converter-bot
-
-# Set the working directory and the entrypoint
-WORKDIR /usr/local/bin
-ENTRYPOINT ["./converter-bot"]
+USER app
+WORKDIR /tmp
+ENV RUST_LOG=info
+ENTRYPOINT ["/usr/local/bin/converter-bot"]

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ just run
 ```
 
 ### Using helper scripts
+
 ```bash
 # Rebuild image + run container
 ./rebuild.sh
@@ -33,34 +34,50 @@ just run
 ```
 
 ### Local Setup (alternative)
+
 ```bash
 cargo build --release
 ./target/release/converter-bot
 ```
 
 ### Using Docker directly (alternative)
+
 ```bash
-docker build -t shitverter .
+# Build production image (multi-stage Dockerfile; final stage is the runtime image).
+docker build -t shitverter:latest .
+
+# Run it.
 docker run -d --env-file .env --name my_shitverter_container shitverter:latest
+
+# Optional: build the reusable toolchain image (Rust + musl) for local builds/debugging.
+docker build --target build-env -t shitverter-buildenv:latest .
+
+# Optional: pin the Rust toolchain image for reproducible builds.
+docker build --build-arg MUSLRUST_TAG=1.93.1-stable-2026-02-23 -t shitverter:latest .
 ```
 
 ## Configuration
+
 Set the following environment variables:
-- `TELOXIDE_TOKEN`: Your Telegram Bot Token.
-- `RUST_LOG`: Log level filter for the bot output (example: `RUST_LOG=info`, default: `info`).
+
+* `TELOXIDE_TOKEN`: Your Telegram Bot Token.
+* `RUST_LOG`: Log level filter for the bot output (example: `RUST_LOG=info`, default: `info`).
 
 If a local `.env` file exists, `run.sh` and `rebuild.sh` automatically pass it to
 `docker run` using `--env-file .env`.
 
 ## Usage
+
 Send a video file (for example, `.webm`, `.mkv`, `.mov`) to the chat with the bot, and it will send a converted `.mp4` file and delete the original message.
 Also shows tg ID's of new members.
 
 ## Rate limits
-- `USER_DAILY_LIMIT` (default: `10`) — maximum conversions per user per UTC day.
-- `GLOBAL_DAILY_LIMIT` (default: `50`) — maximum conversions for the whole bot per UTC day.
+
+* `USER_DAILY_LIMIT` (default: `10`) — maximum conversions per user per UTC day.
+* `GLOBAL_DAILY_LIMIT` (default: `50`) — maximum conversions for the whole bot per UTC day.
 
 The bot logs quota decisions and resets counters at UTC midnight.
 
 ## Contributing
+
 Contributions are welcome. Please send pull requests.

--- a/justfile
+++ b/justfile
@@ -1,6 +1,7 @@
 # Переменные
 container_name := "my_shitverter_container"
 image_name := "shitverter:latest"
+build_env_image_name := "shitverter-buildenv:latest"
 
 # Показать список доступных команд
 default:
@@ -18,3 +19,7 @@ rebuild:
 # Запустить контейнер (без пересборки)
 run:
     IMAGE_NAME={{image_name}} CONTAINER_NAME={{container_name}} ./run.sh
+
+# Собрать toolchain-образ (Rust + musl) для локальной сборки/отладки
+build-env:
+    docker build --target build-env -t {{build_env_image_name}} .


### PR DESCRIPTION
### Motivation
- Make container builds reproducible and faster by introducing a clear multi-stage build with a reusable toolchain stage and dependency caching.
- Reduce production image size and improve runtime security by stripping symbols and running the binary as a non-root user.
- Avoid leaking local artifacts into the build context and document recommended Docker usage for developers.

### Description
- Replaced the previous Dockerfile with a multi-stage pipeline (`build-env` → `builder` → `runtime`) and added an `MUSLRUST_TAG` build-arg for pinning the toolchain.
- Enabled build-time symbol stripping (`RUSTFLAGS`) and switched Cargo invocations to `--locked` with a dependency-cache step to speed rebuilds.
- Hardened the runtime by using `alpine:3.23.3`, installing `ffmpeg` and `ca-certificates`, creating a non-root `app` user, copying the binary with `--chown`, setting `WORKDIR /tmp`, and defaulting `RUST_LOG=info`.
- Added a `.dockerignore` to exclude `target/`, VCS/IDE files, `.env`, and logs, updated `README.md` with production and optional build instructions, and extended `justfile` with a `build-env` recipe and image variable.

### Testing
- `cargo check` ran successfully and finished without errors.
- `git diff --check` reported no whitespace issues in the modified files.
- `just --list` could not be executed in this environment because `just` is not installed, so `justfile` behavior was not validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7ee683cec8332a938c343680c183d)